### PR TITLE
WIP: Add ability to mint an NFT to a provided address

### DIFF
--- a/generated/schema.graphql
+++ b/generated/schema.graphql
@@ -77,7 +77,7 @@ type Mutation {
     """Set collection mint pubkey"""
     setCollectionMint: Boolean!
   ): CandyMachineUploadResult
-  mintNft(encryptedMessage: EncryptedMessage!, nftMetadata: NftMetadata, nftMetadataJSON: File): MintNftResult
+  mintNft(encryptedMessage: EncryptedMessage!, mintToAddress: String, nftMetadata: NftMetadata, nftMetadataJSON: File): MintNftResult
 }
 
 input NftAttribute {

--- a/generated/typings.ts
+++ b/generated/typings.ts
@@ -165,6 +165,7 @@ export interface NexusGenArgTypes {
     }
     mintNft: { // args
       encryptedMessage: NexusGenInputs['EncryptedMessage']; // EncryptedMessage!
+      mintToAddress?: string | null; // String
       nftMetadata?: NexusGenInputs['NftMetadata'] | null; // NftMetadata
       nftMetadataJSON?: NexusGenScalars['File'] | null; // File
     }

--- a/src/graphql/mintNFT.ts
+++ b/src/graphql/mintNFT.ts
@@ -16,8 +16,9 @@ import {
   UploadMetadataOutput,
   Nft,
   CreateNftOutput,
+  CreateNftInput,
 } from '@metaplex-foundation/js-next';
-import { Connection, clusterApiUrl, Keypair } from '@solana/web3.js';
+import { Connection, clusterApiUrl, Keypair, PublicKey } from '@solana/web3.js';
 
 export const MintNftResult = objectType({
   name: 'MintNftResult',
@@ -129,6 +130,9 @@ export const MintNft = mutationField('mintNft', {
     nftMetadataJSON: arg({
       type: 'File',
     }),
+    mintToAddress: arg({
+      type: 'String',
+    })
   },
   async resolve (_, args, ctx: YogaInitialContext) {
     const connection = new Connection(clusterApiUrl('mainnet-beta'));
@@ -137,6 +141,17 @@ export const MintNft = mutationField('mintNft', {
       nft: Nft;
     } & CreateNftOutput = null!;
     let wallet: Keypair = null!;
+
+    let mintToPubkey: PublicKey = null;
+    try {
+      if (args.mintToAddress) {
+        mintToPubkey = new PublicKey(args.mintToAddress!)
+      }
+    } catch (e) {
+      return {
+        message: `Error parsing mint to Address: ${e.message}`,
+      };
+    }
 
     const keyPairBytes = JSON.parse(
       decryptEncodedPayload(args.encryptedMessage),
@@ -177,6 +192,13 @@ export const MintNft = mutationField('mintNft', {
       };
     }
 
+    let create_input_data: CreateNftInput = uri;
+
+    if (mintToPubkey) {
+      // if mintTo arg is provided, we want the NFT owner to be that address instead of being owned by the mint.
+      create_input_data.owner = mintToPubkey
+    }
+    
     // Create New NFT with the metadata
     try {
       nft = await metaplex.nfts().create(uri);

--- a/src/graphql/mintNFT.ts
+++ b/src/graphql/mintNFT.ts
@@ -201,7 +201,7 @@ export const MintNft = mutationField('mintNft', {
     
     // Create New NFT with the metadata
     try {
-      nft = await metaplex.nfts().create(uri);
+      nft = await metaplex.nfts().create(create_input_data);
     } catch (e) {
       return {
         message: `Error creating NFT: ${e.message}`,


### PR DESCRIPTION
Currently when minting NFT's via the graphql mutation, the NFT's end up being owned by the mint. This pr adds the ability to specify an address to be the owner  of the after minting.